### PR TITLE
Handle missing listHerd path in agent

### DIFF
--- a/agent/mcp_agent.py
+++ b/agent/mcp_agent.py
@@ -30,14 +30,24 @@ class MCPAgent:
 
     def list_herd(self, token: str) -> list:
         """Call the listHerd endpoint and return JSON data."""
-        tool = next((t for t in self.context.get('api', {}).get('tools', []) if t.get('name') == 'listHerd'), None)
+        tool = next(
+            (
+                t
+                for t in self.context.get("api", {}).get("tools", [])
+                if t.get("name") == "listHerd"
+            ),
+            None,
+        )
         if tool is None:
-            raise ValueError('listHerd tool not found in model context')
+            raise ValueError("listHerd tool not found in model context")
+        path = tool.get("path")
+        if not path:
+            raise ValueError("listHerd tool path not found in model context")
         import json
         from urllib import request, error
 
         req = request.Request(
-            self.base_url + tool['path'],
+            self.base_url + path,
             headers={
                 'Authorization': f'Bearer {token}',
             },

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,24 @@
+import textwrap
+import pytest
+
+from agent.mcp_agent import MCPAgent
+
+
+def test_list_herd_missing_path(tmp_path):
+    context_file = tmp_path / "context.yaml"
+    context_file.write_text(
+        textwrap.dedent(
+            """
+            api:
+              version: v1
+              tools:
+                - name: listHerd
+                  method: GET
+            """
+        )
+    )
+
+    agent = MCPAgent("http://example.com", context_path=str(context_file))
+    with pytest.raises(ValueError, match="listHerd tool path not found"):
+        agent.list_herd("token")
+


### PR DESCRIPTION
## Summary
- guard against missing `path` field when calling `list_herd`
- test error raised when `listHerd` path is absent from context

## Testing
- `pytest -q` *(fails: command not found)*