### PR TITLE
Improve agent YAML parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ python -m agent http://localhost:8000 --token fake-super-secret-token
 ```
 
 The agent reads `model_context.yaml` to discover the API path and returns the
-JSON response from the server.
+JSON response from the server. For full YAML support install the optional
+`PyYAML` dependency; otherwise a limited built-in parser is used.
 
 ## Running tests
 

--- a/tests/test_parse_context.py
+++ b/tests/test_parse_context.py
@@ -1,0 +1,28 @@
+from agent.mcp_agent import MCPAgent
+
+EXPECTED_CONTEXT = {
+    "schema_version": 1,
+    "api": {
+        "version": "v1",
+        "tools": [
+            {
+                "name": "listHerd",
+                "method": "GET",
+                "path": "/api/v1/herd",
+                "description": "Retrieve herd information",
+                "scopes": ["herd.read"],
+            }
+        ],
+    },
+}
+
+
+def test_parse_context(tmp_path):
+    # Copy model_context.yaml to temporary directory to avoid modifying original
+    src_path = "model_context.yaml"
+    dest = tmp_path / "ctx.yaml"
+    with open(src_path, "r", encoding="utf-8") as f_src:
+        dest.write_text(f_src.read(), encoding="utf-8")
+
+    agent = MCPAgent("http://localhost", context_path=str(dest))
+    assert agent.context == EXPECTED_CONTEXT


### PR DESCRIPTION
## Summary
- parse `model_context.yaml` with `yaml.safe_load` when possible and fall back to the old parser
- clarify README about optional PyYAML requirement
- add a unit test for `_parse_context`

## Testing
- `pytest -q` *(fails: No module named 'pytest')*