### PR TITLE
Add configurable SQLite path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ discoverable, versioned API that can be deployed to AWS Fargate.
 
 1. Seed the SQLite database:
 
+   The database path can be configured via the `DATABASE_PATH` environment
+   variable. If not set it defaults to `mcp.db` inside the working directory.
+
    ```bash
    python -m app.seed
    ```

--- a/app/database.py
+++ b/app/database.py
@@ -1,11 +1,16 @@
+import os
 import sqlite3
 from contextlib import contextmanager
 
-DATABASE_PATH = "mcp.db"
+
+def get_db_path() -> str:
+    """Return the path to the SQLite database."""
+    return os.environ.get("DATABASE_PATH", "mcp.db")
 
 
-def init_db():
-    with sqlite3.connect(DATABASE_PATH) as conn:
+def init_db() -> None:
+    """Create database tables if they do not exist."""
+    with sqlite3.connect(get_db_path()) as conn:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS herd (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, location TEXT)"
         )
@@ -13,7 +18,8 @@ def init_db():
 
 @contextmanager
 def get_db():
-    conn = sqlite3.connect(DATABASE_PATH)
+    """Yield a SQLite connection using the configured database path."""
+    conn = sqlite3.connect(get_db_path())
     try:
         yield conn
     finally:

--- a/tests/test_list_herd.py
+++ b/tests/test_list_herd.py
@@ -1,13 +1,27 @@
+import os
+import tempfile
 from fastapi.testclient import TestClient
+
+fd, db_path = tempfile.mkstemp(suffix=".db")
+os.close(fd)
+os.environ["DATABASE_PATH"] = db_path
 
 from app.main import app
 from app.seed import seed
 
-client = TestClient(app)
+client: TestClient
 
 
 def setup_module(module):
     seed()
+
+    global client
+    client = TestClient(app)
+
+
+def teardown_module(module):
+    if os.path.exists(db_path):
+        os.remove(db_path)
 
 
 def test_list_herd():


### PR DESCRIPTION
## Summary
- make SQLite path configurable via DATABASE_PATH environment variable
- adjust tests to use a temporary database
- document DATABASE_PATH usage in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*